### PR TITLE
Add clojure.org/data.json, because cljs removed it

### DIFF
--- a/dirac
+++ b/dirac
@@ -117,6 +117,7 @@ fi
 DEPS="{:deps {\
   $DIRAC_CLI_DEPS_COORDINATE \
   org.clojure/clojurescript {:mvn/version \"RELEASE\"} \
+  org.clojure/data.json {:mvn/version \"2.4.0\"} \
   clj-logging-config/clj-logging-config {:mvn/version \"1.9.12\"} \
 }}"
 


### PR DESCRIPTION
The dependency org.clojure/data.json was removed from ClojureScript in
version 1.11.51 of May 13th 2022. See [release notes](https://clojurescript.org/news/2022-05-13-release):

> **Vendorization of tools.reader, data.json, and transit-clj**<br>(...)
    After conferring with the Clojure Team, we decided to vendorize all
    these dependencies. This way we can AOT everything and be confident
    that we won’t create a conflict that can’t easily be fixed via
    normal dependency management. (...) The dependance on data.json has
    been removed

This PR adds an explicit dependency on clojure.data.json.

Fixes #98